### PR TITLE
feat: adding sum button in legend to aggregate data in student view

### DIFF
--- a/src/components/common/Legend.js
+++ b/src/components/common/Legend.js
@@ -6,15 +6,21 @@ import FormControlLabel from '@material-ui/core/FormControlLabel';
 import FormControl from '@material-ui/core/FormControl';
 import PropTypes from 'prop-types';
 import Loader from './Loader';
-import { filterVerbs, Occurrence } from '../modes/student/widgets/util';
-import { VERB } from '../modes/student/widgets/types/types';
+import {
+  filterVerbs,
+  Occurrence,
+  addToLegend,
+} from '../modes/student/widgets/util';
+import { VERB } from '../modes/student/widgets/types';
 import updateLegendById from '../../actions/chartLegendById';
 
 const filteredVerbs = ['access', 'cancel', 'login', 'logout', 'unload'];
-const Legend = ({ id }) => {
+
+const Legend = ({ id, addedItems }) => {
   const actions = useSelector(state => state.action.content);
   let verbList = Occurrence(actions, VERB);
   verbList = filterVerbs(verbList, filteredVerbs);
+  verbList = addToLegend(verbList, addedItems);
   const [action, setAction] = useState([]);
   const dispatch = useDispatch();
 
@@ -62,6 +68,7 @@ const Legend = ({ id }) => {
 
 Legend.propTypes = {
   id: PropTypes.string.isRequired,
+  addedItems: PropTypes.arrayOf(PropTypes.string).isRequired,
 };
 
 export default Legend;

--- a/src/components/modes/student/widgets/VerbAvgWidget.js
+++ b/src/components/modes/student/widgets/VerbAvgWidget.js
@@ -4,7 +4,11 @@ import Box from '@material-ui/core/Box';
 import VerbAvgChart from './containers/VerbAvgChart';
 import KeyedDatePicker from '../../../common/KeyedDatePicker';
 import Legend from '../../../common/Legend';
-import { VERB_BAR_DATE_PICKER_ID, VERB_BAR_LEGEND_ID } from './types/types';
+import {
+  VERB_BAR_DATE_PICKER_ID,
+  VERB_BAR_LEGEND_ID,
+  LEGEND_SUM_ATTRIBUTE,
+} from './types';
 
 const VerbAvgWidget = () => {
   const initialState = {
@@ -17,7 +21,7 @@ const VerbAvgWidget = () => {
       <Box display="flex">
         <VerbAvgChart />
         <Box mt={5}>
-          <Legend id={VERB_BAR_LEGEND_ID} />
+          <Legend id={VERB_BAR_LEGEND_ID} addedItems={[LEGEND_SUM_ATTRIBUTE]} />
         </Box>
       </Box>
       <KeyedDatePicker

--- a/src/components/modes/student/widgets/VerbRadarWidget.js
+++ b/src/components/modes/student/widgets/VerbRadarWidget.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import KeyedDatePicker from '../../../common/KeyedDatePicker';
 import VerbRadarChart from './containers/VerbRadarChart';
-import { VERB_RADAR_DATE_PICKER_ID } from './types/types';
+import { VERB_RADAR_DATE_PICKER_ID } from './types';
 
 const VerbAvgWidget = () => {
   const initialState = {

--- a/src/components/modes/student/widgets/containers/VerbRadarChart.js
+++ b/src/components/modes/student/widgets/containers/VerbRadarChart.js
@@ -1,12 +1,6 @@
 import { connect } from 'react-redux';
 import RadarChart from '../components/RadarChart';
-import {
-  AVG,
-  USER,
-  USER_ID,
-  VERB,
-  VERB_RADAR_DATE_PICKER_ID,
-} from '../types/types';
+import { AVG, USER, USER_ID, VERB, VERB_RADAR_DATE_PICKER_ID } from '../types';
 import {
   buildDateRange,
   fillDataForRadar,

--- a/src/components/modes/student/widgets/types/ComponentsId.js
+++ b/src/components/modes/student/widgets/types/ComponentsId.js
@@ -1,8 +1,3 @@
-export const USER_ID = 'userId';
-export const DATE = 'date';
-export const VERB = 'verb';
-export const USER = 'You';
-export const AVG = 'Average';
 export const VERB_RADAR_DATE_PICKER_ID = 'VERB_RADAR_DATE_PICKER_ID';
 export const VERB_BAR_DATE_PICKER_ID = 'VERB_BAR_DATE_PICKER_ID';
 export const VERB_BAR_LEGEND_ID = 'VERB_BAR_LEGEND_ID';

--- a/src/components/modes/student/widgets/types/attributes.js
+++ b/src/components/modes/student/widgets/types/attributes.js
@@ -1,0 +1,6 @@
+export const USER_ID = 'userId';
+export const DATE = 'date';
+export const VERB = 'verb';
+export const USER = 'You';
+export const AVG = 'Average';
+export const LEGEND_SUM_ATTRIBUTE = 'Sum';

--- a/src/components/modes/student/widgets/types/index.js
+++ b/src/components/modes/student/widgets/types/index.js
@@ -1,0 +1,2 @@
+export * from './ComponentsId';
+export * from './attributes';

--- a/src/components/modes/student/widgets/util/common.js
+++ b/src/components/modes/student/widgets/util/common.js
@@ -76,6 +76,10 @@ export const filterVerbs = (verbList, list) => {
   return filteredList;
 };
 
+export const addToLegend = (verbList, addedItem) => {
+  return [...verbList, ...addedItem];
+};
+
 export const RemovePropertyOfObject = (Obj, property) => {
   const newObj = {};
 

--- a/src/components/modes/student/widgets/util/verbAvgBarChartData.js
+++ b/src/components/modes/student/widgets/util/verbAvgBarChartData.js
@@ -89,3 +89,39 @@ export const displayTheSelectedData = (data, dataSelected) => {
   });
   return updatedDataArray;
 };
+
+const createAggregateDataObject = (userKeyName, avgKeyName, dataObject) => {
+  const updatedDataObject = {};
+  updatedDataObject[userKeyName] = 0;
+  updatedDataObject[avgKeyName] = 0;
+  updatedDataObject.date = dataObject.date;
+  return updatedDataObject;
+};
+
+function addTotalAction(actionsInaDay, userKeyName, avgKeyName) {
+  const aggregateDataObject = createAggregateDataObject(
+    userKeyName,
+    avgKeyName,
+    actionsInaDay,
+  );
+  Object.keys(actionsInaDay).forEach(key => {
+    if (key !== 'date') {
+      if (key.indexOf('Avg') === -1) {
+        aggregateDataObject[userKeyName] += actionsInaDay[key];
+      } else {
+        aggregateDataObject[avgKeyName] += actionsInaDay[key];
+      }
+    }
+  });
+  return aggregateDataObject;
+}
+
+export const aggregateData = (actionsInDataRange, userKeyName, avgKeyName) => {
+  const updatedDataArray = [];
+  actionsInDataRange.forEach(actionsInaDay => {
+    updatedDataArray.push(
+      addTotalAction(actionsInaDay, userKeyName, avgKeyName),
+    );
+  });
+  return updatedDataArray;
+};

--- a/src/components/modes/student/widgets/util/verbAvgRadarChartData.js
+++ b/src/components/modes/student/widgets/util/verbAvgRadarChartData.js
@@ -1,4 +1,4 @@
-import { AVG, USER } from '../types/types';
+import { AVG, USER } from '../types/attributes';
 
 export const formatDataForRadar = (key, attribute, properties = []) => {
   const data = [];


### PR DESCRIPTION
Hello @HadiKhai , a sum button feature was added to the chart in the student view that will allow the user to calculate the total actions made with respect to the average:

![image](https://user-images.githubusercontent.com/45897168/86168729-4853fc80-bb21-11ea-8864-0c29428c22bf.png)
Notice that When sum is clicked its calculate the total of actions chosen. 

Uncheked:

![image](https://user-images.githubusercontent.com/45897168/86169607-93bada80-bb22-11ea-9d3f-64ec594b6dcd.png)


Note that: 

>  Legend between the two charts are not in the same order `You` & `Average`.

> The sum button is added to the Legend component in the Check box group the way it is made easily reusable is that the extra items (i.e: Sum ) is added to the Legend through props and inside the Legend component the item is added to the group of check Boxes. (Image below)

![image](https://user-images.githubusercontent.com/45897168/86169220-f5c71000-bb21-11ea-915b-73fbdbd20d43.png)


